### PR TITLE
Improve install stability

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        if_ci_failed: ignore #success, failure, error, ignore
+        informational: false
+        only_pulls: false

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 *
+Dockerfile*
+.dockerignore
 !metator/*
 !setup.py
 !setup.cfg
+!metator.yaml
 !requirements.txt
 !MANIFEST.in
 !README.md

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,15 +23,6 @@ jobs:
     
     - uses: actions/checkout@v3
 
-
-
-    - name: Install Conda environment from metator.yaml
-      uses: mamba-org/provision-with-micromamba@main
-      with:
-        environment-file: metator.yaml
-        extra-specs: |
-          python=${{ matrix.python-version }}
-
     - name: Load apt packages
       run: |
         sudo apt-get update
@@ -52,13 +43,19 @@ jobs:
         ./gradlew build
         cd ..
 
+    - name: Install Conda environment from metator.yaml
+      uses: mamba-org/setup-micromamba@v1
+      with:
+          environment-file: metator.yaml
+          generate-run-shell: true
+          extra-specs: |
+            python=${{ matrix.python-version }}
+
     - name: Test with pytest
       run: |
         micromamba activate metator
         export LOUVAIN_PATH=external/gen-louvain
         export LEIDEN_PATH=networkanalysis/build/libs/networkanalysis-1.2.0.jar
-        PWD=$(pwd)
-        export PATH="$PATH:$PWD/bwa:$PWD/pairix/bin/:$PWD/pairix/util:$PWD/pairix/util/bam2pairs:/root/.local/bin"
         pytest --pylint --pylint-error-types=EF --pylint-rcfile=.pylintrc --doctest-modules metator
         pytest --cov=metator
         codecov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,7 @@ jobs:
       with:
           environment-file: metator.yaml
           generate-run-shell: true
-          extra-specs: |
+          create-args: >-
             python=${{ matrix.python-version }}
 
     - name: Test with pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tests_data/assembly.fa.fxi
 tests_data/outdir/cam.pdf
 nohup.out
 codecov*
+!.codecov.yml
 
 # vscode
 .vscode

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Metagenomic Tridimensional Organisation-based Reassembly - A set of scripts that
 
 ### Requirements
 
-* Python 3.6 or later is required.
+* Python `3.8` to `3.10` or later is required.
 * The following librairies are required but will be automatically installed with the pip installation: `numpy`, `scipy`, `sklearn`, `pandas`, `docopt`, `networkx` `biopython` `pyfastx`, `pysam`, `micomplete` and `pairix`.
 * The following software should be installed separately if you used the pip installation:
   * [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)

--- a/README.md
+++ b/README.md
@@ -17,14 +17,20 @@ Metagenomic Tridimensional Organisation-based Reassembly - A set of scripts that
 
 ## Table of contents
 
-* [Installation](#Installation)
-  * [Requirements](#Requirements)
-  * [Using pip](#Using-pip)
-  * [Using docker container](#Using-docker-container)
-* [Usage](#Usage)
-* [Output files](#Output-files)
-* [References](#References)
-* [Contact](#Contact)
+1. [MetaTOR](#metator)
+   1. [Table of contents](#table-of-contents)
+   2. [Installation](#installation)
+      1. [Requirements](#requirements)
+      2. [Using pip](#using-pip)
+      3. [Using conda](#using-conda)
+      4. [Louvain or Leiden dependency](#louvain-or-leiden-dependency)
+      5. [Using docker container](#using-docker-container)
+   3. [Usage](#usage)
+   4. [Output files](#output-files)
+   5. [References](#references)
+   6. [Contact](#contact)
+      1. [Authors](#authors)
+      2. [Research lab](#research-lab)
 
 ## Installation
 
@@ -45,13 +51,13 @@ Metagenomic Tridimensional Organisation-based Reassembly - A set of scripts that
 ### Using pip
 
 ```sh
-   pip3 install metator
+pip3 install metator
 ```
 
 or, to use the latest version:
 
 ```sh
-   pip3 install -e git+https://github.com/koszullab/metator.git@master#egg=metator
+pip3 install -e git+https://github.com/koszullab/metator.git@master#egg=metator
 ```
 
 ### Using conda
@@ -85,13 +91,13 @@ export LEIDEN_PATH=/networkanalysis_repository_path/build/libs/networkanalysis-1
 A dockerfile is also available if that is of interest. You may fetch the image by running the following:
 
 ```sh
-    docker pull koszullab/metator
+docker pull koszullab/metator
 ```
 
 ## Usage
 
 ```sh
-    metator {network|partition|validation|pipeline} [parameters]
+metator {network|partition|validation|pipeline} [parameters]
 ```
 
 A metaTOR command takes the form `metator action --param1 arg1 --param2

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Metagenomic Tridimensional Organisation-based Reassembly - A set of scripts that
 ### Requirements
 
 * Python 3.6 or later is required.
-* The following librairies are required but will be automatically installed with the pip installation: `numpy`, `scipy`, `sklearn`, `pandas`, `docopt`, `networkx` `biopython` `pyfastx` and `pysam`.
+* The following librairies are required but will be automatically installed with the pip installation: `numpy`, `scipy`, `sklearn`, `pandas`, `docopt`, `networkx` `biopython` `pyfastx`, `pysam`, `micomplete` and `pairix`.
 * The following software should be installed separately if you used the pip installation:
   * [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)
   * [samtools](http://www.htslib.org/)
@@ -45,8 +45,6 @@ Metagenomic Tridimensional Organisation-based Reassembly - A set of scripts that
         implementation).
   * [networkanalysis](https://github.com/vtraag/networkanalysis) (not
     necessary only if you want to use Leiden algorithm to partition the network)
-  * [micomplete](https://bitbucket.org/evolegiolab/micomplete/src/master/)
-  * [pairix](https://github.com/4dn-dcic/pairix) (not necessary if you do not use metator contact map)
 
 ### Using pip
 

--- a/metator.yaml
+++ b/metator.yaml
@@ -7,6 +7,7 @@ dependencies:
   - requests
   - pip
   - git
+  - biopython=1.80
   - bowtie2=2.5.1
   - bwa=0.7.17
   - samtools=1.17
@@ -15,17 +16,15 @@ dependencies:
   - pysam=0.21.0
   - pairix=0.3.7
   - pairtools=1.0.2
+  - pyfastx==0.8.4
+  - cooler==0.9.1
+  - pandas==1.5.3
+  - hicstuff
   - pip:
-    - pyfastx==0.8.4
     - micomplete==1.1.1
-    - cooler==0.9.1
-    - pandas==1.5.3
-    - git+https://github.com/koszullab/hicstuff.git
     - metator
     - pytest
     - pylint
-    - pytest-cov
-    - pylint
-    - pytest-pylint
     - codecov
-    
+    - pytest-cov
+    - pytest-pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ checkv
 docopt
 hicstuff
 looseversion
-micomplete
+micomplete==1.1.1
 networkx
 numpy
 pairtools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biopython
+biopython==1.80
 cdlib
 checkv
 docopt

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     classifiers=CLASSIFIERS,
     url=URL,
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.8,<=3.10",
     include_package_data=True,
     long_description_content_type="text/markdown",
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
- GHA run on python 3.6 -> 3.11
- Dockerfile is updated
- `biopython` pinned to 1.80 and `micomplete` pinned to 1.1.1
