### PR TITLE
Hotfix: wrong dtype in `mge` module

### DIFF
--- a/src/metator/mge.py
+++ b/src/metator/mge.py
@@ -749,7 +749,7 @@ def update_mge_data(mges_data: pd.DataFrame, bins: List[Tuple]) -> pd.DataFrame:
         Dictionary of the mge bins.
     """
     # Initiation
-    mges_data["MetaTOR_MGE_bin"] = 0.0
+    mges_data["MetaTOR_MGE_bin"] = 0
     mges_data["MetaTOR_MGE_Score"] = 0.0
     bin_id = 0
     mge_bins = {}


### PR DESCRIPTION
Fixes https://github.com/koszullab/metaTOR/issues/29: changed the initialization of `mges_data["MetaTOR_MGE_bin"]` from `0.0` (float) to `0` (integer) to ensure consistency with expected data types.